### PR TITLE
V4.1.0

### DIFF
--- a/priv/ezcodeprofiler.ex
+++ b/priv/ezcodeprofiler.ex
@@ -33,16 +33,32 @@ defmodule EZProfiler.CodeProfiler do
 
   end
 
-  def function_profiling(fun, args) do
+  def function_profiling(fun) do
+    Kernel.apply(fun, [])
+  end
+
+  def function_profiling(fun, args) when is_list(args) do
     Kernel.apply(fun, args)
+  end
+
+  def function_profiling(fun, _label_or_fun)  do
+    Kernel.apply(fun, [])
   end
 
   def function_profiling(fun, args, _label_or_fun)  do
     Kernel.apply(fun, args)
   end
 
-  def pipe_profiling(arg, fun, args) do
+  def pipe_profiling(arg, fun) do
+    Kernel.apply(fun, [arg])
+  end
+
+  def pipe_profiling(arg, fun, args) when is_list(args) do
     Kernel.apply(fun, [arg|args])
+  end
+
+  def pipe_profiling(arg, fun, _label_or_fun) do
+    Kernel.apply(fun, [arg])
   end
 
   def pipe_profiling(arg, fun, args, _label_or_fun) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,16 @@
-ExUnit.start()
+defmodule EZProfiler.Test do
+
+   def block_test1() do
+
+   end
+
+   def start_code_profiling(), do:
+      start_code_profiling(:any_label)
+
+   def start_code_profiling(label), do:
+      EZProfiler.ProfilerOnTarget.allow_code_profiling(node(), label)
+
+   defp display_messsage(message), do:
+    send({:main_event_handler, :ezprofiler@localhost}, {:display_message, {:message, message}})
+
+end


### PR DESCRIPTION
* Fixed issue where code profiling included extra methods that shouldn't be profiled
* Allow functions with a 0 arity
* Tidied documentation
* Added --cpfo option